### PR TITLE
Autofix: Placeholder styled are not applied after bumping from 3.4.5 to 3.4.7

### DIFF
--- a/src/strategies.ts
+++ b/src/strategies.ts
@@ -33,7 +33,7 @@ function isRootSelector(selector: string) {
 }
 
 function isPseudoElementSelector(ruleSelector: string) {
-  return ruleSelector.includes('::');
+  return ruleSelector.includes('::') && !ruleSelector.includes('::placeholder');
 }
 
 /**
@@ -74,7 +74,7 @@ export const isolateInsideOfContainer: SelectorBasedStrategy<{
         return `${ruleSelector}${whereNotExcept} ${whereDirect}`;
       }
       return selectorsArray.map((s) => `${s}${whereNotExcept}`).join(',');
-    } else if (ruleSelector === '*' || isPseudoElementSelector(ruleSelector)) {
+    } else if (ruleSelector === '*' || isPseudoElementSelector(ruleSelector) || ruleSelector.includes('::placeholder')) {
       return prependWithCustomSelectors(ruleSelector);
     }
     return `${ruleSelector}${whereWithSubs}${whereNotExcept}`;


### PR DESCRIPTION
Modified the isPseudoElementSelector function to exclude ::placeholder from being treated as a pseudo-element. This ensures that placeholder styles are applied correctly. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    