### PR TITLE
Accept kebab-case option keys (isolation-strategy, root-styles)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Key changes from v3:
 
 Two isolation strategies are available, covering 99% of cases:
 
-|                                    Strategy                                     | Description                                                                                                                                                                             |
-| :-----------------------------------------------------------------------------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-|   `isolationStrategy: inside`<br/><img src="docs/inside.png" alt="inside" width="220"/>   | Everything is protected from preflight styles, except the specified Tailwind root(s).<br/>Use it when all your Tailwind-powered content lives **inside some root container**.           |
+|                                         Strategy                                         | Description                                                                                                                                                                                |
+| :--------------------------------------------------------------------------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|  `isolationStrategy: inside`<br/><img src="docs/inside.png" alt="inside" width="220"/>   | Everything is protected from preflight styles, except the specified Tailwind root(s).<br/>Use it when all your Tailwind-powered content lives **inside some root container**.              |
 | `isolationStrategy: outside`<br/><img src="docs/outside.png" alt="outside" width="220"/> | Protects specific root(s) from preflight styles — Tailwind is everywhere outside.<br/>Use it when Tailwind is everywhere, but you want to **exclude some part of the DOM** from preflight. |
 
 # Quick Start
@@ -75,7 +75,7 @@ This includes Tailwind's **global preflight** (CSS reset) — which is exactly w
 
 #### 3.1 Lock Tailwind preflight inside a container
 
-Use `isolationStrategy: inside` when all your Tailwind-powered content is under a single root element (like `.twp`). Preflight styles will only apply within that container.
+Use `isolation-strategy: inside` when all your Tailwind-powered content is under a single root element (like `.twp`). Preflight styles will only apply within that container.
 
 ```css
 /* input.css */
@@ -83,30 +83,32 @@ Use `isolationStrategy: inside` when all your Tailwind-powered content is under 
 @import "tailwindcss/utilities";
 
 @plugin "tailwindcss-scoped-preflight" {
-  isolationStrategy: inside;
+  isolation-strategy: inside;
   selector: .twp;
 }
 ```
+
+> Kebab-case keys (`isolation-strategy`, `root-styles`) are the recommended form inside `@plugin` blocks — CSS formatters like Prettier lowercase property names, which breaks the camelCase keys (`isolationStrategy`, `rootStyles`). The camelCase keys are still accepted for backwards compatibility.
 
 With an exclusion zone (to protect third-party markup nested under `.twp`):
 
 ```css
 @plugin "tailwindcss-scoped-preflight" {
-  isolationStrategy: inside;
+  isolation-strategy: inside;
   selector: .twp;
   except: .no-twp;
 }
 ```
 
-|          Option           | Value                          | Description                                                                                                  |
-| :-----------------------: | ------------------------------ | ------------------------------------------------------------------------------------------------------------ |
-|   `isolationStrategy`     | `inside`                       | Required. Activates the inside-container isolation mode.                                                     |
-|      `selector`           | CSS selector (or comma-list)   | Required. The container(s) where Tailwind content lives. e.g. `.twp` or `.twp, [twp]`                       |
-|   `except` (optional)     | CSS selector                   | Excludes nested elements from preflight. Useful for third-party markup under `.twp`.                         |
-| `rootStyles` (optional)   | `move to container` (default)  | Moves root styles (html/body/:host) to the container selector.                                               |
-|                           | `add :where`                   | Keeps root styles on root selectors but wraps them with `:where` so only matching items are affected.        |
-|   `ignore` (optional)     | Comma-separated CSS selectors  | Keeps these preflight selectors untouched (skipped by the isolation strategy). e.g. `html, :host, *`         |
-|   `remove` (optional)     | Comma-separated CSS selectors  | Removes preflight styles for these selectors entirely. e.g. `body, :before, :after`                          |
+|         Option          | Value                         | Description                                                                                           |
+| :---------------------: | ----------------------------- | ----------------------------------------------------------------------------------------------------- |
+|   `isolationStrategy`   | `inside`                      | Required. Activates the inside-container isolation mode.                                              |
+|       `selector`        | CSS selector (or comma-list)  | Required. The container(s) where Tailwind content lives. e.g. `.twp` or `.twp, [twp]`                 |
+|   `except` (optional)   | CSS selector                  | Excludes nested elements from preflight. Useful for third-party markup under `.twp`.                  |
+| `rootStyles` (optional) | `move to container` (default) | Moves root styles (html/body/:host) to the container selector.                                        |
+|                         | `add :where`                  | Keeps root styles on root selectors but wraps them with `:where` so only matching items are affected. |
+|   `ignore` (optional)   | Comma-separated CSS selectors | Keeps these preflight selectors untouched (skipped by the isolation strategy). e.g. `html, :host, *`  |
+|   `remove` (optional)   | Comma-separated CSS selectors | Removes preflight styles for these selectors entirely. e.g. `body, :before, :after`                   |
 
 #### 3.2 Exclude a container from Tailwind preflight
 
@@ -118,7 +120,7 @@ Use `isolationStrategy: outside` when Tailwind is used everywhere, but you want 
 @import "tailwindcss/utilities";
 
 @plugin "tailwindcss-scoped-preflight" {
-  isolationStrategy: outside;
+  isolation-strategy: outside;
   selector: .no-twp;
 }
 ```
@@ -127,19 +129,19 @@ With a `plus` selector (to re-enable preflight for Tailwind components nested in
 
 ```css
 @plugin "tailwindcss-scoped-preflight" {
-  isolationStrategy: outside;
+  isolation-strategy: outside;
   selector: .no-twp;
   plus: .twp;
 }
 ```
 
-|        Option         | Value                         | Description                                                                                                     |
-| :-------------------: | ----------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `isolationStrategy`   | `outside`                     | Required. Activates the outside-container isolation mode.                                                        |
-|    `selector`         | CSS selector (or comma-list)  | Required. The container(s) to protect from preflight. e.g. `.no-twp`                                            |
-|  `plus` (optional)    | CSS selector                  | Re-enables preflight for Tailwind components nested inside the excluded zone. e.g. `.twp`                       |
-| `ignore` (optional)   | Comma-separated CSS selectors | Keeps these preflight selectors untouched (skipped by the isolation strategy).                                   |
-| `remove` (optional)   | Comma-separated CSS selectors | Removes preflight styles for these selectors entirely.                                                           |
+|       Option        | Value                         | Description                                                                               |
+| :-----------------: | ----------------------------- | ----------------------------------------------------------------------------------------- |
+| `isolationStrategy` | `outside`                     | Required. Activates the outside-container isolation mode.                                 |
+|     `selector`      | CSS selector (or comma-list)  | Required. The container(s) to protect from preflight. e.g. `.no-twp`                      |
+|  `plus` (optional)  | CSS selector                  | Re-enables preflight for Tailwind components nested inside the excluded zone. e.g. `.twp` |
+| `ignore` (optional) | Comma-separated CSS selectors | Keeps these preflight selectors untouched (skipped by the isolation strategy).            |
+| `remove` (optional) | Comma-separated CSS selectors | Removes preflight styles for these selectors entirely.                                    |
 
 #### Choosing a good selector
 
@@ -149,7 +151,7 @@ Use a dedicated plain class name (`.twp`, `.no-twp`) or a data attribute (`[data
 
 ```tsx
 export function MyApp({ children }: PropsWithChildren) {
-  return <div className={'twp'}>{children}</div>;
+  return <div className={"twp"}>{children}</div>;
 }
 ```
 
@@ -159,7 +161,7 @@ export function MyApp({ children }: PropsWithChildren) {
 
 ```css
 @plugin "tailwindcss-scoped-preflight" {
-  isolationStrategy: inside;
+  isolation-strategy: inside;
   selector: .twp, [twp];
 }
 ```
@@ -172,7 +174,7 @@ Use `ignore` to pass certain preflight selectors through without modification:
 
 ```css
 @plugin "tailwindcss-scoped-preflight" {
-  isolationStrategy: inside;
+  isolation-strategy: inside;
   selector: .twp;
   ignore: html, :host, *;
 }
@@ -184,7 +186,7 @@ Use `remove` to strip preflight styles for specific selectors entirely:
 
 ```css
 @plugin "tailwindcss-scoped-preflight" {
-  isolationStrategy: inside;
+  isolation-strategy: inside;
   selector: .twp;
   remove: body, :before, :after;
 }
@@ -196,22 +198,22 @@ Use `remove` to strip preflight styles for specific selectors entirely:
 
 TailwindCSS v4 still supports JavaScript configuration via `@config`, though it's [deprecated in favor of CSS-first configuration](https://tailwindcss.com/docs/functions-and-directives#config-directive). This plugin works with both approaches — **choose one, not both:**
 
-| Approach | How | Recommended? |
-|----------|-----|:------------:|
-| **CSS-first** (`@plugin`) | Configure in your `.css` file | ✅ Yes |
+| Approach                  | How                               |         Recommended?          |
+| ------------------------- | --------------------------------- | :---------------------------: |
+| **CSS-first** (`@plugin`) | Configure in your `.css` file     |            ✅ Yes             |
 | **JS config** (`@config`) | Configure in `tailwind.config.js` | For SCSS or gradual migration |
 
 ### Using `@config` with this plugin
 
 ```javascript
 // tailwind.config.js
-import scopedPreflightStyles from 'tailwindcss-scoped-preflight';
+import scopedPreflightStyles from "tailwindcss-scoped-preflight";
 
 export default {
   plugins: [
     scopedPreflightStyles({
-      isolationStrategy: 'inside',
-      selector: '.twp',
+      isolationStrategy: "inside",
+      selector: ".twp",
     }),
   ],
 };
@@ -252,7 +254,7 @@ Move the `@plugin` directive and Tailwind imports to a plain `.css` file, then i
 @import "tailwindcss/utilities";
 
 @plugin "tailwindcss-scoped-preflight" {
-  isolationStrategy: inside;
+  isolation-strategy: inside;
   selector: .twp;
 }
 ```
@@ -287,33 +289,36 @@ TailwindCSS v4 replaced JavaScript config files with a CSS-first API. This plugi
 
 ## Quick reference
 
-| v3 (tailwind.config.js)                                           | v4 (input.css)                                         |
-| ----------------------------------------------------------------- | ------------------------------------------------------ |
-| `plugins: [scopedPreflightStyles({ ... })]`                       | `@plugin "tailwindcss-scoped-preflight" { ... }`       |
-| `import { scopedPreflightStyles, isolateInsideOfContainer }`      | No JS import needed (or `import scopedPreflightStyles` with `@config`) |
-| `isolationStrategy: isolateInsideOfContainer('.twp')`             | `isolationStrategy: inside; selector: .twp;`           |
-| `isolationStrategy: isolateOutsideOfContainer('.no-twp')`         | `isolationStrategy: outside; selector: .no-twp;`       |
-| `['.twp', '[twp]']` (array)                                       | `selector: .twp, [twp];` (comma-separated)             |
-| `{ except: '.no-twp' }`                                           | `except: .no-twp;`                                     |
-| `{ plus: '.twp' }`                                                | `plus: .twp;`                                          |
-| `{ ignore: ['html', ':host'] }`                                   | `ignore: html, :host;`                                 |
-| `{ remove: ['body'] }`                                            | `remove: body;`                                        |
-| `modifyPreflightStyles: { ... }`                                  | Not available in v4                                    |
-| Custom `isolationStrategy` function                               | Not available in v4                                    |
-| `isolateForComponents`                                            | Not available in v4 — use `inside` strategy instead    |
+| v3 (tailwind.config.js)                                      | v4 (input.css)                                                         |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------- |
+| `plugins: [scopedPreflightStyles({ ... })]`                  | `@plugin "tailwindcss-scoped-preflight" { ... }`                       |
+| `import { scopedPreflightStyles, isolateInsideOfContainer }` | No JS import needed (or `import scopedPreflightStyles` with `@config`) |
+| `isolationStrategy: isolateInsideOfContainer('.twp')`        | `isolationStrategy: inside; selector: .twp;`                           |
+| `isolationStrategy: isolateOutsideOfContainer('.no-twp')`    | `isolationStrategy: outside; selector: .no-twp;`                       |
+| `['.twp', '[twp]']` (array)                                  | `selector: .twp, [twp];` (comma-separated)                             |
+| `{ except: '.no-twp' }`                                      | `except: .no-twp;`                                                     |
+| `{ plus: '.twp' }`                                           | `plus: .twp;`                                                          |
+| `{ ignore: ['html', ':host'] }`                              | `ignore: html, :host;`                                                 |
+| `{ remove: ['body'] }`                                       | `remove: body;`                                                        |
+| `modifyPreflightStyles: { ... }`                             | Not available in v4                                                    |
+| Custom `isolationStrategy` function                          | Not available in v4                                                    |
+| `isolateForComponents`                                       | Not available in v4 — use `inside` strategy instead                    |
 
 ## Before/after: inside strategy
 
 **v3 (tailwind.config.js):**
 
 ```javascript
-import { scopedPreflightStyles, isolateInsideOfContainer } from 'tailwindcss-scoped-preflight';
+import {
+  scopedPreflightStyles,
+  isolateInsideOfContainer,
+} from "tailwindcss-scoped-preflight";
 
 export default {
   plugins: [
     scopedPreflightStyles({
-      isolationStrategy: isolateInsideOfContainer('.twp', {
-        except: '.no-twp',
+      isolationStrategy: isolateInsideOfContainer(".twp", {
+        except: ".no-twp",
       }),
     }),
   ],
@@ -327,7 +332,7 @@ export default {
 @import "tailwindcss/utilities";
 
 @plugin "tailwindcss-scoped-preflight" {
-  isolationStrategy: inside;
+  isolation-strategy: inside;
   selector: .twp;
   except: .no-twp;
 }
@@ -338,13 +343,16 @@ export default {
 **v3 (tailwind.config.js):**
 
 ```javascript
-import { scopedPreflightStyles, isolateOutsideOfContainer } from 'tailwindcss-scoped-preflight';
+import {
+  scopedPreflightStyles,
+  isolateOutsideOfContainer,
+} from "tailwindcss-scoped-preflight";
 
 export default {
   plugins: [
     scopedPreflightStyles({
-      isolationStrategy: isolateOutsideOfContainer('.no-twp', {
-        plus: '.twp',
+      isolationStrategy: isolateOutsideOfContainer(".no-twp", {
+        plus: ".twp",
       }),
     }),
   ],
@@ -358,7 +366,7 @@ export default {
 @import "tailwindcss/utilities";
 
 @plugin "tailwindcss-scoped-preflight" {
-  isolationStrategy: outside;
+  isolation-strategy: outside;
   selector: .no-twp;
   plus: .twp;
 }
@@ -370,15 +378,15 @@ export default {
 
 ```javascript
 scopedPreflightStyles({
-  isolationStrategy: isolateInsideOfContainer(['.twp', '[twp]']),
-})
+  isolationStrategy: isolateInsideOfContainer([".twp", "[twp]"]),
+});
 ```
 
 **v4 (input.css):**
 
 ```css
 @plugin "tailwindcss-scoped-preflight" {
-  isolationStrategy: inside;
+  isolation-strategy: inside;
   selector: .twp, [twp];
 }
 ```
@@ -387,9 +395,9 @@ scopedPreflightStyles({
 
 The following v3 features are not available in v4. TailwindCSS 4 moved away from JavaScript config entirely, so any feature that required a JS callback or JS-level hook cannot be supported.
 
-| Feature | v3 Usage | Why removed |
-| ------- | -------- | ----------- |
-| `modifyPreflightStyles` | Object or function callback to alter individual CSS declarations | TW4 has no hook mechanism for JS-based style modification — all config is CSS strings |
-| Custom `isolationStrategy` function | `isolationStrategy: ({ ruleSelector }) => string` | `@plugin` CSS blocks only accept string scalar values, not functions |
-| `isolateForComponents` | Named export, was already deprecated in v3 | Deprecated in v3; removed in v4. Use `isolationStrategy: inside` with `rootStyles: add :where` for the same effect |
-| Named strategy imports | `import { isolateInsideOfContainer } from 'tailwindcss-scoped-preflight'` | No JS config to import into — use `@plugin` directive or default import with `@config` |
+| Feature                             | v3 Usage                                                                  | Why removed                                                                                                        |
+| ----------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `modifyPreflightStyles`             | Object or function callback to alter individual CSS declarations          | TW4 has no hook mechanism for JS-based style modification — all config is CSS strings                              |
+| Custom `isolationStrategy` function | `isolationStrategy: ({ ruleSelector }) => string`                         | `@plugin` CSS blocks only accept string scalar values, not functions                                               |
+| `isolateForComponents`              | Named export, was already deprecated in v3                                | Deprecated in v3; removed in v4. Use `isolationStrategy: inside` with `rootStyles: add :where` for the same effect |
+| Named strategy imports              | `import { isolateInsideOfContainer } from 'tailwindcss-scoped-preflight'` | No JS config to import into — use `@plugin` directive or default import with `@config`                             |

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -397,9 +397,23 @@ function isolateOutsideOfContainer(containerSelectors, options) {
 // src/index.ts
 var import_meta = {};
 var USAGE_EXAMPLE = `  @plugin "tailwindcss-scoped-preflight" {
-    isolationStrategy: inside;
+    isolation-strategy: inside;
     selector: .twp;
   }`;
+var KEBAB_ALIASES = {
+  "isolation-strategy": "isolationStrategy",
+  "root-styles": "rootStyles"
+};
+function normalizeOptionKeys(raw) {
+  const out = { ...raw };
+  for (const [kebab, camel] of Object.entries(KEBAB_ALIASES)) {
+    if (kebab in out) {
+      if (!(camel in out)) out[camel] = out[kebab];
+      delete out[kebab];
+    }
+  }
+  return out;
+}
 function parseCommaList(value) {
   return value ? value.split(",").map((s) => s.trim()) : void 0;
 }
@@ -451,12 +465,17 @@ Example:
 ${USAGE_EXAMPLE}`
       );
     }
-    const strategy = resolveStrategy(options);
+    const normalized = normalizeOptionKeys(
+      options
+    );
+    const strategy = resolveStrategy(normalized);
     const req = typeof require !== "undefined" ? require : (0, import_node_module.createRequire)(import_meta.url);
     const baseCssPath = req.resolve("tailwindcss/preflight.css");
     const baseCssStyles = import_postcss.default.parse((0, import_node_fs.readFileSync)(baseCssPath, "utf8"));
     baseCssStyles.walkRules((rule) => {
-      rule.selectors = rule.selectors.map((s) => strategy({ ruleSelector: s })).filter((value, index2, array) => value && array.indexOf(value) === index2);
+      rule.selectors = rule.selectors.map((s) => strategy({ ruleSelector: s })).filter(
+        (value, index2, array) => value && array.indexOf(value) === index2
+      );
       rule.selector = rule.selectors.join(",\n");
       if (!rule.nodes.some((n) => n instanceof import_postcss.default.Declaration)) {
         rule.nodes = [];

--- a/dist/index.d.cts
+++ b/dist/index.d.cts
@@ -144,12 +144,12 @@ type ExclusiveKeys<T> = keyof Omit<T, keyof StrategyBaseOptions>;
 type InsidePluginOptions = CSSPluginBase & Pick<InsideStrategyOptions, ExclusiveKeys<InsideStrategyOptions>> & {
     [K in ExclusiveKeys<OutsideStrategyOptions>]?: never;
 } & {
-    isolationStrategy: 'inside';
+    isolationStrategy: "inside";
 };
 type OutsidePluginOptions = CSSPluginBase & Pick<OutsideStrategyOptions, ExclusiveKeys<OutsideStrategyOptions>> & {
     [K in ExclusiveKeys<InsideStrategyOptions>]?: never;
 } & {
-    isolationStrategy: 'outside';
+    isolationStrategy: "outside";
 };
 type V4PluginOptions = InsidePluginOptions | OutsidePluginOptions;
 /**
@@ -159,7 +159,7 @@ type V4PluginOptions = InsidePluginOptions | OutsidePluginOptions;
  * @example
  * ```css
  * @plugin "tailwindcss-scoped-preflight" {
- *   isolationStrategy: inside;
+ *   isolation-strategy: inside;
  *   selector: .twp;
  * }
  * ```

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -144,12 +144,12 @@ type ExclusiveKeys<T> = keyof Omit<T, keyof StrategyBaseOptions>;
 type InsidePluginOptions = CSSPluginBase & Pick<InsideStrategyOptions, ExclusiveKeys<InsideStrategyOptions>> & {
     [K in ExclusiveKeys<OutsideStrategyOptions>]?: never;
 } & {
-    isolationStrategy: 'inside';
+    isolationStrategy: "inside";
 };
 type OutsidePluginOptions = CSSPluginBase & Pick<OutsideStrategyOptions, ExclusiveKeys<OutsideStrategyOptions>> & {
     [K in ExclusiveKeys<InsideStrategyOptions>]?: never;
 } & {
-    isolationStrategy: 'outside';
+    isolationStrategy: "outside";
 };
 type V4PluginOptions = InsidePluginOptions | OutsidePluginOptions;
 /**
@@ -159,7 +159,7 @@ type V4PluginOptions = InsidePluginOptions | OutsidePluginOptions;
  * @example
  * ```css
  * @plugin "tailwindcss-scoped-preflight" {
- *   isolationStrategy: inside;
+ *   isolation-strategy: inside;
  *   selector: .twp;
  * }
  * ```

--- a/dist/index.js
+++ b/dist/index.js
@@ -390,9 +390,23 @@ function isolateOutsideOfContainer(containerSelectors, options) {
 
 // src/index.ts
 var USAGE_EXAMPLE = `  @plugin "tailwindcss-scoped-preflight" {
-    isolationStrategy: inside;
+    isolation-strategy: inside;
     selector: .twp;
   }`;
+var KEBAB_ALIASES = {
+  "isolation-strategy": "isolationStrategy",
+  "root-styles": "rootStyles"
+};
+function normalizeOptionKeys(raw) {
+  const out = { ...raw };
+  for (const [kebab, camel] of Object.entries(KEBAB_ALIASES)) {
+    if (kebab in out) {
+      if (!(camel in out)) out[camel] = out[kebab];
+      delete out[kebab];
+    }
+  }
+  return out;
+}
 function parseCommaList(value) {
   return value ? value.split(",").map((s) => s.trim()) : void 0;
 }
@@ -444,12 +458,17 @@ Example:
 ${USAGE_EXAMPLE}`
       );
     }
-    const strategy = resolveStrategy(options);
+    const normalized = normalizeOptionKeys(
+      options
+    );
+    const strategy = resolveStrategy(normalized);
     const req = typeof __require !== "undefined" ? __require : createRequire(import.meta.url);
     const baseCssPath = req.resolve("tailwindcss/preflight.css");
     const baseCssStyles = postcss.parse(readFileSync(baseCssPath, "utf8"));
     baseCssStyles.walkRules((rule) => {
-      rule.selectors = rule.selectors.map((s) => strategy({ ruleSelector: s })).filter((value, index2, array) => value && array.indexOf(value) === index2);
+      rule.selectors = rule.selectors.map((s) => strategy({ ruleSelector: s })).filter(
+        (value, index2, array) => value && array.indexOf(value) === index2
+      );
       rule.selector = rule.selectors.join(",\n");
       if (!rule.nodes.some((n) => n instanceof postcss.Declaration)) {
         rule.nodes = [];

--- a/e2e/insideKebab/index.html
+++ b/e2e/insideKebab/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Inside v4</title>
+    <link rel="stylesheet" href="stylesout.css" />
+  </head>
+  <body>
+    <p class="twp">
+      twp content
+      <button class="no-twp">excluded button</button>
+      <button>twp button</button>
+    </p>
+    <p>outside content</p>
+    <!-- ISOL-04: Pseudo-element scoping -->
+    <div class="twp">
+      <div data-has-height class="after:block after:size-12 after:bg-blue-500"></div>
+    </div>
+    <div data-no-height class="after:block after:size-12 after:bg-blue-500"></div>
+  </body>
+</html>

--- a/e2e/insideKebab/input.css
+++ b/e2e/insideKebab/input.css
@@ -1,0 +1,7 @@
+@import "tailwindcss/theme";
+@import "tailwindcss/utilities";
+@plugin "../../dist/index.js" {
+  isolation-strategy: inside;
+  selector: .twp;
+  except: .no-twp;
+}

--- a/e2e/insideKebab/insideKebab.spec.ts
+++ b/e2e/insideKebab/insideKebab.spec.ts
@@ -1,0 +1,34 @@
+import { test } from "@playwright/test";
+import { testTheScenario } from "../utils";
+import {
+  coloredBg,
+  hasHeight,
+  hasLineHeight,
+  hasMargin,
+  hasNoMargin,
+  transparentBg,
+} from "../validators";
+
+// Regression test: kebab-case option keys (isolation-strategy) must produce
+// the same output as camelCase (isolationStrategy). CSS formatters like
+// Prettier lowercase property names, so kebab-case is the formatter-safe form.
+test("v4 Inside of container (kebab-case options)", async ({
+  page,
+}, testInfo) => {
+  await testTheScenario(
+    {
+      url: "./insideKebab/",
+      rules: {
+        body: hasMargin,
+        "p.twp": hasNoMargin,
+        "p.twp~p:not(.twp)": hasMargin,
+        "p.twp button.no-twp": coloredBg,
+        "p.twp .no-twp+button": transparentBg,
+        "body > p.twp": hasLineHeight,
+        ".twp div[data-has-height]": hasHeight,
+      },
+    },
+    page,
+    testInfo,
+  );
+});

--- a/e2e/insideKebab/stylesout.css
+++ b/e2e/insideKebab/stylesout.css
@@ -1,0 +1,325 @@
+/*! tailwindcss v4.2.2 | MIT License | https://tailwindcss.com */
+@layer properties;
+:root, :host {
+  --font-sans: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+    'Noto Color Emoji';
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+  --color-blue-500: oklch(62.3% 0.214 259.815);
+  --color-black: #000;
+  --spacing: 0.25rem;
+  --default-font-family: var(--font-sans);
+  --default-mono-font-family: var(--font-mono);
+}
+.visible {
+  visibility: visible;
+}
+.start {
+  inset-inline-start: var(--spacing);
+}
+.end {
+  inset-inline-end: var(--spacing);
+}
+.container {
+  width: 100%;
+  @media (width >= 40rem) {
+    max-width: 40rem;
+  }
+  @media (width >= 48rem) {
+    max-width: 48rem;
+  }
+  @media (width >= 64rem) {
+    max-width: 64rem;
+  }
+  @media (width >= 80rem) {
+    max-width: 80rem;
+  }
+  @media (width >= 96rem) {
+    max-width: 96rem;
+  }
+}
+.block {
+  display: block;
+}
+.contents {
+  display: contents;
+}
+.flex {
+  display: flex;
+}
+.flex-shrink {
+  flex-shrink: 1;
+}
+.flex-grow {
+  flex-grow: 1;
+}
+.transform {
+  transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
+}
+.lowercase {
+  text-transform: lowercase;
+}
+.after\:block {
+  &::after {
+    content: var(--tw-content);
+    display: block;
+  }
+}
+.after\:size-12 {
+  &::after {
+    content: var(--tw-content);
+    width: calc(var(--spacing) * 12);
+    height: calc(var(--spacing) * 12);
+  }
+}
+.after\:border {
+  &::after {
+    content: var(--tw-content);
+    border-style: var(--tw-border-style);
+    border-width: 1px;
+  }
+}
+.after\:border-black {
+  &::after {
+    content: var(--tw-content);
+    border-color: var(--color-black);
+  }
+}
+.after\:bg-blue-500 {
+  &::after {
+    content: var(--tw-content);
+    background-color: var(--color-blue-500);
+  }
+}
+@layer base {
+  *:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+:where(.twp,.twp *):where(:not(.no-twp,.no-twp *))::after,
+:where(.twp,.twp *):where(:not(.no-twp,.no-twp *))::before,
+:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) ::backdrop,
+:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) ::file-selector-button {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    border: 0 solid;
+  }
+  .twp:where(:not(.no-twp,.no-twp *)) {
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
+    font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji');
+    font-feature-settings: var(--default-font-feature-settings, normal);
+    font-variation-settings: var(--default-font-variation-settings, normal);
+    -webkit-tap-highlight-color: transparent;
+  }
+  hr:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) {
+    height: 0;
+    color: inherit;
+    border-top-width: 1px;
+  }
+  abbr:where([title]):where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) {
+    -webkit-text-decoration: underline dotted;
+    text-decoration: underline dotted;
+  }
+  h1:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+h2:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+h3:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+h4:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+h5:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+h6:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+  a:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) {
+    color: inherit;
+    -webkit-text-decoration: inherit;
+    text-decoration: inherit;
+  }
+  b:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+strong:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) {
+    font-weight: bolder;
+  }
+  code:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+kbd:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+samp:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+pre:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) {
+    font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace);
+    font-feature-settings: var(--default-mono-font-feature-settings, normal);
+    font-variation-settings: var(--default-mono-font-variation-settings, normal);
+    font-size: 1em;
+  }
+  small:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) {
+    font-size: 80%;
+  }
+  sub:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+sup:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+  sub:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) {
+    bottom: -0.25em;
+  }
+  sup:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) {
+    top: -0.5em;
+  }
+  table:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) {
+    text-indent: 0;
+    border-color: inherit;
+    border-collapse: collapse;
+  }
+  :-moz-focusring:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) {
+    outline: auto;
+  }
+  progress:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) {
+    vertical-align: baseline;
+  }
+  summary:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) {
+    display: list-item;
+  }
+  ol:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+ul:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+menu:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) {
+    list-style: none;
+  }
+  img:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+svg:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+video:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+canvas:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+audio:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+iframe:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+embed:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+object:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) {
+    display: block;
+    vertical-align: middle;
+  }
+  img:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+video:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) {
+    max-width: 100%;
+    height: auto;
+  }
+  button:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+input:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+select:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+optgroup:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+textarea:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) ::file-selector-button {
+    font: inherit;
+    font-feature-settings: inherit;
+    font-variation-settings: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    border-radius: 0;
+    background-color: transparent;
+    opacity: 1;
+  }
+  :where(select:is([multiple], [size])) optgroup:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) {
+    font-weight: bolder;
+  }
+  :where(select:is([multiple], [size])) optgroup option:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) {
+    padding-inline-start: 20px;
+  }
+  :where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) ::file-selector-button {
+    margin-inline-end: 4px;
+  }
+  :where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) ::placeholder {
+    opacity: 1;
+  }
+  @supports (not (-webkit-appearance: -apple-pay-button))  or
+  (contain-intrinsic-size: 1px) {
+    :where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) ::placeholder {
+      color: currentcolor;
+      @supports (color: color-mix(in lab, red, red)) {
+        color: color-mix(in oklab, currentcolor 50%, transparent);
+      }
+    }
+  }
+  textarea:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) {
+    resize: vertical;
+  }
+  :where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) ::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+  :where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) ::-webkit-date-and-time-value {
+    min-height: 1lh;
+    text-align: inherit;
+  }
+  :where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) ::-webkit-datetime-edit {
+    display: inline-flex;
+  }
+  :where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) ::-webkit-datetime-edit-fields-wrapper {
+    padding: 0;
+  }
+  :where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) ::-webkit-datetime-edit,
+:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) ::-webkit-datetime-edit-year-field,
+:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) ::-webkit-datetime-edit-month-field,
+:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) ::-webkit-datetime-edit-day-field,
+:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) ::-webkit-datetime-edit-hour-field,
+:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) ::-webkit-datetime-edit-minute-field,
+:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) ::-webkit-datetime-edit-second-field,
+:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) ::-webkit-datetime-edit-millisecond-field,
+:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) ::-webkit-datetime-edit-meridiem-field {
+    padding-block: 0;
+  }
+  :where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) ::-webkit-calendar-picker-indicator {
+    line-height: 1;
+  }
+  :-moz-ui-invalid:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) {
+    box-shadow: none;
+  }
+  button:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+input:where([type='button'], [type='reset'], [type='submit']):where(.twp,.twp *):where(:not(.no-twp,.no-twp *)),
+:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) ::file-selector-button {
+    appearance: button;
+  }
+  :where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) ::-webkit-inner-spin-button,
+:where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) ::-webkit-outer-spin-button {
+    height: auto;
+  }
+  [hidden]:where(:not([hidden='until-found'])):where(.twp,.twp *):where(:not(.no-twp,.no-twp *)) {
+    display: none !important;
+  }
+}
+@property --tw-rotate-x {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-rotate-y {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-rotate-z {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-skew-x {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-skew-y {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-content {
+  syntax: "*";
+  initial-value: "";
+  inherits: false;
+}
+@property --tw-border-style {
+  syntax: "*";
+  inherits: false;
+  initial-value: solid;
+}
+@layer properties {
+  @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color:rgb(from red r g b)))) {
+    *, ::before, ::after, ::backdrop {
+      --tw-rotate-x: initial;
+      --tw-rotate-y: initial;
+      --tw-rotate-z: initial;
+      --tw-skew-x: initial;
+      --tw-skew-y: initial;
+      --tw-content: "";
+      --tw-border-style: solid;
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-import { readFileSync } from 'node:fs';
-import { createRequire } from 'node:module';
-import postcss from 'postcss';
-import postcssJs from 'postcss-js';
-import plugin from 'tailwindcss/plugin';
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import postcss from "postcss";
+import postcssJs from "postcss-js";
+import plugin from "tailwindcss/plugin";
 import {
   type CSSRuleSelectorTransformer,
   type InsideStrategyOptions,
@@ -10,7 +10,7 @@ import {
   type StrategyBaseOptions,
   isolateInsideOfContainer,
   isolateOutsideOfContainer,
-} from './strategies.js';
+} from "./strategies.js";
 
 // CSS @plugin blocks pass ignore/remove as comma-separated strings, not arrays
 interface CSSPluginBase {
@@ -23,35 +23,57 @@ interface CSSPluginBase {
 type ExclusiveKeys<T> = keyof Omit<T, keyof StrategyBaseOptions>;
 
 type InsidePluginOptions = CSSPluginBase &
-  Pick<InsideStrategyOptions, ExclusiveKeys<InsideStrategyOptions>> &
-  { [K in ExclusiveKeys<OutsideStrategyOptions>]?: never } &
-  { isolationStrategy: 'inside' };
+  Pick<InsideStrategyOptions, ExclusiveKeys<InsideStrategyOptions>> & {
+    [K in ExclusiveKeys<OutsideStrategyOptions>]?: never;
+  } & { isolationStrategy: "inside" };
 
 type OutsidePluginOptions = CSSPluginBase &
-  Pick<OutsideStrategyOptions, ExclusiveKeys<OutsideStrategyOptions>> &
-  { [K in ExclusiveKeys<InsideStrategyOptions>]?: never } &
-  { isolationStrategy: 'outside' };
+  Pick<OutsideStrategyOptions, ExclusiveKeys<OutsideStrategyOptions>> & {
+    [K in ExclusiveKeys<InsideStrategyOptions>]?: never;
+  } & { isolationStrategy: "outside" };
 
 type V4PluginOptions = InsidePluginOptions | OutsidePluginOptions;
 
-const USAGE_EXAMPLE = `  @plugin "tailwindcss-scoped-preflight" {\n    isolationStrategy: inside;\n    selector: .twp;\n  }`;
+const USAGE_EXAMPLE = `  @plugin "tailwindcss-scoped-preflight" {\n    isolation-strategy: inside;\n    selector: .twp;\n  }`;
+
+// Prettier (and other CSS formatters) lowercase property names in @plugin blocks
+// because CSS property names are case-insensitive. Accept kebab-case aliases so
+// users don't need to opt out of formatting for these files.
+const KEBAB_ALIASES: Record<string, string> = {
+  "isolation-strategy": "isolationStrategy",
+  "root-styles": "rootStyles",
+};
+
+function normalizeOptionKeys<T extends Record<string, unknown>>(raw: T): T {
+  const out: Record<string, unknown> = { ...raw };
+  for (const [kebab, camel] of Object.entries(KEBAB_ALIASES)) {
+    if (kebab in out) {
+      if (!(camel in out)) out[camel] = out[kebab];
+      delete out[kebab];
+    }
+  }
+  return out as T;
+}
 
 function parseCommaList(value?: string): string[] | undefined {
-  return value ? value.split(',').map((s) => s.trim()) : undefined;
+  return value ? value.split(",").map((s) => s.trim()) : undefined;
 }
 
 // Escape colons in container selectors so Tailwind modifier separators
 // (e.g. .xl:px-foo) become valid CSS (e.g. .xl\:px-foo).
 // Container selectors are simple class/ID selectors — no pseudo-classes expected.
 function escapeSelectorColon(selector: string): string {
-  return selector.replace(/(?<!\\):/g, '\\:');
+  return selector.replace(/(?<!\\):/g, "\\:");
 }
 
 function parseSelectors(raw: string | string[]): string[] {
   const list = Array.isArray(raw)
     ? raw.map((s) => s.trim()).filter(Boolean)
-    : typeof raw === 'string'
-      ? raw.split(',').map((s) => s.trim()).filter(Boolean)
+    : typeof raw === "string"
+      ? raw
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean)
       : [];
 
   if (list.length === 0) {
@@ -68,7 +90,7 @@ function resolveStrategy(options: V4PluginOptions): CSSRuleSelectorTransformer {
   const ignore = parseCommaList(options.ignore);
   const remove = parseCommaList(options.remove);
 
-  if (options.isolationStrategy === 'inside') {
+  if (options.isolationStrategy === "inside") {
     return isolateInsideOfContainer(selectors, {
       ignore,
       remove,
@@ -77,7 +99,7 @@ function resolveStrategy(options: V4PluginOptions): CSSRuleSelectorTransformer {
     });
   }
 
-  if (options.isolationStrategy === 'outside') {
+  if (options.isolationStrategy === "outside") {
     return isolateOutsideOfContainer(selectors, {
       ignore,
       remove,
@@ -98,7 +120,7 @@ function resolveStrategy(options: V4PluginOptions): CSSRuleSelectorTransformer {
  * @example
  * ```css
  * @plugin "tailwindcss-scoped-preflight" {
- *   isolationStrategy: inside;
+ *   isolation-strategy: inside;
  *   selector: .twp;
  * }
  * ```
@@ -113,17 +135,25 @@ export const scopedPreflightStyles = plugin.withOptions<V4PluginOptions>(
           `tailwindcss-scoped-preflight: plugin options are required.\nExample:\n${USAGE_EXAMPLE}`,
         );
       }
-      const strategy = resolveStrategy(options);
+      const normalized = normalizeOptionKeys(
+        options as unknown as Record<string, unknown>,
+      ) as unknown as V4PluginOptions;
+      const strategy = resolveStrategy(normalized);
 
-      const req = typeof require !== 'undefined' ? require : createRequire(import.meta.url);
-      const baseCssPath = req.resolve('tailwindcss/preflight.css');
-      const baseCssStyles = postcss.parse(readFileSync(baseCssPath, 'utf8'));
+      const req =
+        typeof require !== "undefined"
+          ? require
+          : createRequire(import.meta.url);
+      const baseCssPath = req.resolve("tailwindcss/preflight.css");
+      const baseCssStyles = postcss.parse(readFileSync(baseCssPath, "utf8"));
 
       baseCssStyles.walkRules((rule) => {
         rule.selectors = rule.selectors
           .map((s) => strategy({ ruleSelector: s }))
-          .filter((value, index, array) => value && array.indexOf(value) === index);
-        rule.selector = rule.selectors.join(',\n');
+          .filter(
+            (value, index, array) => value && array.indexOf(value) === index,
+          );
+        rule.selector = rule.selectors.join(",\n");
         if (!rule.nodes.some((n) => n instanceof postcss.Declaration)) {
           rule.nodes = [];
         }
@@ -138,7 +168,11 @@ export const scopedPreflightStyles = plugin.withOptions<V4PluginOptions>(
             cleanedRoot.append(node.clone());
           }
         } else if (node instanceof postcss.Comment) {
-          if (next instanceof postcss.Rule && next.selector && next.nodes.length > 0) {
+          if (
+            next instanceof postcss.Rule &&
+            next.selector &&
+            next.nodes.length > 0
+          ) {
             cleanedRoot.append(node.clone());
           }
         } else {


### PR DESCRIPTION
Fixes #70.

CSS formatters (Prettier) lowercase property names inside `@plugin { ... }` blocks because CSS properties are case-insensitive, turning `isolationStrategy` into `isolationstrategy` — which the plugin then rejects.

This PR accepts `isolation-strategy` and `root-styles` as aliases. Existing camelCase keys keep working (non-breaking). Error message + README examples updated to kebab-case.

Added e2e fixture `e2e/insideKebab/` mirroring `inside/` to cover the kebab-case parse path; `npm run test/build` passes and its `stylesout.css` is byte-identical to `inside/stylesout.css`. Full Playwright run not executed in this environment.